### PR TITLE
Add rule audit-argument-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Finally, enable all of the rules that you would like to use.
   "rules": {
     "meteor/no-session": 1,
     "meteor/no-blaze-lifecycle-assignment": 2,
-    "meteor/no-blaze-zero-timeout": 2
+    "meteor/no-blaze-zero-timeout": 2,
+    "meteor/audit-argument-checks": 2
   }
 }
 ```
@@ -49,6 +50,7 @@ Finally, enable all of the rules that you would like to use.
 * [no-session](docs/rules/no-session.md): Prevent usage of Session
 * [no-blaze-lifecycle-assignment](docs/rules/no-blaze-lifecycle-assignment.md): Prevent deprecated template lifecycle callback assignments
 * [no-zero-timeout](docs/rules/no-zero-timeout.md): Prevent usage of Meteor.setTimeout with zero delay
+* [audit-argument-checks](docs/rules/audit-argument-checks.md): Enforce check on all arguments passed to methods and publish functions
 
 ## To Do
 

--- a/docs/rules/audit-argument-checks.md
+++ b/docs/rules/audit-argument-checks.md
@@ -1,0 +1,58 @@
+# Enforce check on all arguments passed to methods and publish functions (audit-argument-checks)
+
+The Meteor package `audit-argument-checks` requires that all arguments in calls to methods and publish functions are `check`ed.
+Any method that does not pass each one of its arguments to check will throw an error.
+This rule emulates that behavior. Unlike its Meteor counterpart this rule further ensures all `check`'s happen unconditionally.
+
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+
+Meteor.publish("foo", function (bar) {})
+
+Meteor.methods({
+  foo: function (bar) {}
+})
+
+Meteor.methods({
+  foo: function (bar) {
+    if (Math.random() > 0.5) {
+      check(bar, Match.Any)
+    }
+  }
+})
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+Meteor.publish("foo", function (bar) {
+  check(bar, Match.Any)
+})
+
+Meteor.methods({
+  foo: function (bar) {
+    check(bar, Match.Any)
+  }
+})
+
+```
+
+
+## When Not To Use It
+
+If you are not using Meteor's `check` package, then you should not use this rule.
+
+## Further Reading
+
+* http://docs.meteor.com/#/full/check
+* http://docs.meteor.com/#/full/auditargumentchecks
+
+## Possible Improvements
+
+* Emulate behavior of Meteor's `audit-argument-checks` more closely

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@ module.exports = {
   rules: {
     'no-session': require('./lib/rules/no-session'),
     'no-blaze-lifecycle-assignment': require('./lib/rules/no-blaze-lifecycle-assignment'),
-    'no-zero-timeout': require('./lib/rules/no-zero-timeout')
+    'no-zero-timeout': require('./lib/rules/no-zero-timeout'),
+    'audit-argument-checks': require('./lib/rules/audit-argument-checks')
   },
   rulesConfig: {
     'no-session': 0,
     'no-blaze-lifecycle-assignment': 0,
-    'no-zero-timeout': 0
+    'no-zero-timeout': 0,
+    'audit-argument-checks': 0
   }
 };

--- a/lib/rules/audit-argument-checks.js
+++ b/lib/rules/audit-argument-checks.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Enforce check on all arguments passed to methods and publish functions
+ * @author Dominik Ferber
+ */
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Rule Definition
+// -----------------------------------------------------------------------------
+
+
+module.exports = function (context) {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function auditArgumentChecks (node) {
+    if (node.type === 'FunctionExpression') {
+      var checkedParams = [];
+
+      // short-circuit
+      if (node.params.length === 0) {
+        return;
+      }
+
+      node.body.body.map(function (expression) {
+        if (
+          expression.type === 'ExpressionStatement' &&
+          expression.expression.type === 'CallExpression' &&
+          expression.expression.callee.type === 'Identifier' &&
+          expression.expression.callee.name === 'check' &&
+          expression.expression.arguments.length > 1 &&
+          expression.expression.arguments[0].type === 'Identifier'
+        ) {
+          checkedParams.push(expression.expression.arguments[0].name);
+        }
+      });
+
+      node.params.map(function (param) {
+        if (param.type === 'Identifier') {
+          if (checkedParams.indexOf(param.name) === -1) {
+            context.report(param, param.name + ' is not checked');
+          }
+        }
+      });
+    }
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Public
+  // ---------------------------------------------------------------------------
+
+  return {
+    CallExpression: function (node) {
+      if (
+        node.callee.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.object.type === 'Identifier' && node.callee.object.name === 'Meteor'
+      ) {
+
+        // publications
+        if (node.callee.property.name === 'publish') {
+          if (node.arguments.length < 2) {
+            return;
+          }
+
+          auditArgumentChecks(node.arguments[1]);
+        }
+
+        // method
+        if (node.callee.property.name === 'methods') {
+          if (
+            node.arguments.length > 0 &&
+            node.arguments[0].type === 'ObjectExpression'
+          ) {
+            node.arguments[0].properties.map(function (property) {
+              auditArgumentChecks(property.value);
+            });
+          }
+        }
+      }
+    }
+  };
+
+};
+
+module.exports.schema = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "eslint-plugin-meteor",
-  "version": "0.4.0",
   "author": "Dominik Ferber <dominik.ferber+npm@gmail.com>",
   "description": "Meteor specific linting rules for ESLint",
   "main": "index.js",
@@ -28,6 +27,7 @@
     "coveralls": "2.11.4",
     "cz-conventional-changelog": "1.0.1",
     "eslint": "1.5.1",
+    "babel-eslint": "4.1.3",
     "ghooks": "0.3.2",
     "istanbul": "0.3.21",
     "mocha": "2.3.3",

--- a/tests/lib/rules/audit-argument-checks.js
+++ b/tests/lib/rules/audit-argument-checks.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Enforce check on all arguments passed to methods and publish functions
+ * @author Dominik Ferber
+ */
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/audit-argument-checks');
+var RuleTester = require('eslint').RuleTester;
+
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('audit-argument-checks', rule, {
+
+  valid: [
+    'foo()',
+
+    'Meteor[x]()',
+    'Meteor["publish"]()',
+    'Meteor.publish()',
+
+    {code: 'Meteor.publish("foo", function ({ x }) {})', parser: 'babel-eslint'},
+    'Meteor.publish("foo", function () {})',
+    'Meteor.publish("foo", function (bar) { check(bar, Match.Any); })',
+    'Meteor.publish("foo", function (bar, baz) { check(bar, Match.Any); check(baz, Match.Any); })',
+
+    'Meteor.methods()',
+    'Meteor.methods({ x: function () {} })',
+    'Meteor.methods({ x: true })',
+    {code: 'Meteor.methods({ x () {} })', parser: 'babel-eslint'},
+    'Meteor.methods({ x: function (bar) { check(bar, Match.Any); } })',
+    'Meteor.methods({ x: function (bar, baz) { check(bar, Match.Any); check(baz, Match.Any); } })'
+  ],
+
+  invalid: [
+    {
+      code: 'Meteor.publish("foo", function (bar) { foo(); })',
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }]
+    },
+    {
+      code: 'Meteor.publish("foo", function (bar) {})',
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }]
+    },
+    {
+      code: 'Meteor.publish("foo", function (bar, baz) { check(bar, Match.Any); })',
+      errors: [{
+        message: 'baz is not checked',
+        type: 'Identifier'
+      }]
+    },
+    {
+      code: 'Meteor.methods({ foo: function (bar) {} })',
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }]
+    },
+    {
+      code: 'Meteor.methods({ foo: function () {}, foo2: function (bar) {} })',
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }]
+    },
+    {
+      code: 'Meteor.methods({ foo () {}, foo2 (bar) {} })',
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    },
+    {
+      code: [
+        'Meteor.methods({' +
+        '  foo () {},' +
+        '  foo2 (bar) {' +
+        '    if (true) {' +
+        '      check(bar, Meteor.any)' +
+        '    }' +
+        '  }' +
+        '})'
+      ].join('\n'),
+      errors: [{
+        message: 'bar is not checked',
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    }
+  ]
+});


### PR DESCRIPTION
Also enables `babel-eslint` to parse and lint ES6 code.