### PR TITLE
Upgrade to ESLint v3 (second try)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ branches:
 notifications:
   email: false
 node_js:
-  - 0.10
-  - 0.12
-  - iojs
   - 4
+  - 6
 before_install:
   - npm i -g npm@^3.0.0
   - npm -v

--- a/package.json
+++ b/package.json
@@ -39,17 +39,17 @@
   "bugs": "https://github.com/dferber90/eslint-plugin-meteor/issues",
   "dependencies": {
     "babel-polyfill": "6.9.1",
-    "babel-register": "6.11.5",
-    "babel-runtime": "6.9.2",
+    "babel-register": "6.11.6",
+    "babel-runtime": "6.11.6",
     "escope": "3.6.0",
     "invariant": "2.2.1",
     "lodash.find": "4.5.1",
-    "lodash.memoize": "4.1.0",
+    "lodash.memoize": "4.1.1",
     "path-exists": "3.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.11.4",
-    "babel-core": "6.10.4",
+    "babel-core": "6.11.4",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-runtime": "6.12.0",
     "babel-preset-es2015": "6.9.0",
@@ -57,9 +57,9 @@
     "colors": "1.1.2",
     "coveralls": "2.11.12",
     "cz-conventional-changelog": "1.1.6",
-    "eslint": "3.0.0",
+    "eslint": "3.2.0",
     "eslint-config-airbnb": "9.0.1",
-    "eslint-plugin-import": "1.11.1",
+    "eslint-plugin-import": "1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.0",
     "eslint-plugin-react": "5.2.2",
     "ghooks": "1.3.2",
@@ -72,7 +72,7 @@
     "validate-commit-msg": "2.6.1"
   },
   "peerDependencies": {
-    "eslint": ">=0.8.0"
+    "eslint": "^2.0.0 || ^3.0.0"
   },
   "engines": {},
   "keywords": [


### PR DESCRIPTION
Changes
- chore: upgrade multiple dependencies
- chore(npm): require ESLint v2 or v3
- chore(travis-ci): drop node 0.10, 0.12 and iojs. add v6

Upgraded
- babel-core 6.11.4
- babel-register 6.11.6
- babel-runtime 6.11.6
- eslint 3.2.0
- eslint-plugin-import 1.12.0
- lodash.memoize 4.1.1

See http://eslint.org/docs/user-guide/migrating-to-3.0.0 for upgrade guide.

closes #292, closes #289, closes #288, closes #287, closes #285, closes #278

BREAKING CHANGE: Upgrade ESLint to v3. This removes support for node < v4. See [upgrade guide](http://eslint.org/docs/user-guide/migrating-to-3.0.0) for upgrade steps.