### PR TITLE
remove babel-polyfill

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import auditArgumentChecks from './rules/audit-argument-checks'
 import noSession from './rules/no-session'
 import noBlazeLifecycleAssignment from './rules/no-template-lifecycle-assignments'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "branch": "master"
   },
   "scripts": {
-    "build": "babel lib -d dist --optional runtime",
+    "build": "babel lib -d dist",
     "build:w": "npm run build -- --watch",
     "coverage:check": "nyc check-coverage --lines 100 --functions 100 --branches 100",
     "coverage:report": "nyc report",
@@ -38,7 +38,6 @@
   "homepage": "https://github.com/dferber90/eslint-plugin-meteor",
   "bugs": "https://github.com/dferber90/eslint-plugin-meteor/issues",
   "dependencies": {
-    "babel-polyfill": "6.16.0",
     "babel-register": "6.16.3",
     "babel-runtime": "6.11.6",
     "escope": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
   "peerDependencies": {
     "eslint": "^3.7.0"
   },
-  "engines": {},
+  "engines": {
+    "node": ">=4"
+  },
   "keywords": [
     "eslint",
     "eslint-plugin",


### PR DESCRIPTION
Using babel-runtime is enough (https://babeljs.io/docs/plugins/transform-runtime/).

closes #364