### PR TITLE
fix(release): upgrade to npm@5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ node_js:
   - 4
   - 6
 before_install:
-  - npm i -g npm@^3.0.0
+  - npm i -g npm@^5.3.0
   - npm -v
   - npm i -g codeclimate-test-reporter
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ notifications:
 node_js:
   - 4
   - 6
+  - 8
 before_install:
-  - npm i -g npm@^5.3.0
+  - npm i -g npm@^3.0.0
   - npm -v
   - npm i -g codeclimate-test-reporter
 before_script:


### PR DESCRIPTION
The prepublishOnly hook was not executed because npm was running v3 still.

Closes #521 