### PR TITLE
chore(travis): avoid reporting failing coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - npm i -g codeclimate-test-reporter
 
 script:
-  - npm run test
+  - npm run test || travis_terminate 1
   - codeclimate-test-reporter < ./coverage/lcov.info
   - npm run coveralls
 


### PR DESCRIPTION
By default TravisCI will run each `script`, even when an earlier script failed. The added `|| travis_terminate 1` will avoid running subsequent scripts when the `npm test` command failed.