### PR TITLE
Remove unnecessary "plugins" from example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Create an `.eslintrc.json` file with this content at the root of your project:
 
 ```json
 {
-  "plugins": ["meteor"],
   "extends": ["plugin:meteor/recommended"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ To enable the recommended configuration use the extends property in your `.eslin
 
 ```json
 {
-  "plugins": [
-    "meteor"
-  ],
   "extends": ["eslint:recommended", "plugin:meteor/recommended"]
 }
 ```


### PR DESCRIPTION
Hi 👋 First of all, thanks for your work 👍 

I've noticed that there is an unnecessary plugins field in the example config.
The plugin is already included in the `meteor/recommended` config which is being extended
https://github.com/dferber90/eslint-plugin-meteor/blob/master/lib/index.js#L24

Examples from other repos:

React https://github.com/yannickcr/eslint-plugin-react
* only `extends` in the example config
* plugin included in config https://github.com/yannickcr/eslint-plugin-react/blob/master/index.js#L152

Vue https://github.com/vuejs/eslint-plugin-vue
* only `extends` in the example config
* plugin included in config https://github.com/vuejs/eslint-plugin-vue/blob/80b8983118cc08cf473642c05413bcb930c93613/lib/configs/base.js#L16