### PR TITLE
Allow simple assignment statements in check() calls

### DIFF
--- a/docs/rules/audit-argument-checks.md
+++ b/docs/rules/audit-argument-checks.md
@@ -41,14 +41,26 @@ Meteor.methods({
   }
 })
 
+Meteor.methods({
+  foo: function (bar) {
+    var ret;
+    ret = check(bar, Match.Any)
+  }
+})
+
 ```
+
+For a check function to be considered "called", it must be called at the
+top level of the method or publish function (not e.g. within an `if` block),
+either as a lone expression statement or as an assignment statement where the
+right-hand side is just the function call (as in the last example above).
 
 ### Options
 
 If you define your own functions that call `check`, you can provide a list of
 such functions via the configuration `checkEquivalents`.  This rule assumes
 that these functions effectively check their first argument (an identifier or
-a list of identifiers).
+an array of identifiers).
 
 For example, in `.eslintrc.json`, you can specify the following configuration:
 

--- a/lib/rules/audit-argument-checks.js
+++ b/lib/rules/audit-argument-checks.js
@@ -52,6 +52,16 @@ module.exports = {
       }
 
       const checkedParams = [];
+      function processCheckArgs(args) {
+        if (args.length > 0 && args[0].type === 'Identifier') {
+          checkedParams.push(args[0].name);
+        }
+        if (args.length > 0 && args[0].type === 'ArrayExpression') {
+          args[0].elements.forEach((element) => {
+            if (element.type === 'Identifier') checkedParams.push(element.name);
+          });
+        }
+      }
 
       // short-circuit
       if (node.params.length === 0) {
@@ -64,24 +74,17 @@ module.exports = {
             expression.type === 'ExpressionStatement' &&
             expression.expression.type === 'CallExpression' &&
             expression.expression.callee.type === 'Identifier' &&
-            isCheck(expression.expression) &&
-            expression.expression.arguments.length > 0 &&
-            expression.expression.arguments[0].type === 'Identifier'
+            isCheck(expression.expression)
           ) {
-            checkedParams.push(expression.expression.arguments[0].name);
-          }
-          if (
+            processCheckArgs(expression.expression.arguments);
+          } else if (
             expression.type === 'ExpressionStatement' &&
-            expression.expression.type === 'CallExpression' &&
-            expression.expression.callee.type === 'Identifier' &&
-            isCheck(expression.expression) &&
-            expression.expression.arguments.length > 0 &&
-            expression.expression.arguments[0].type === 'ArrayExpression'
+            expression.expression.type === 'AssignmentExpression' &&
+            expression.expression.right.type === 'CallExpression' &&
+            expression.expression.right.callee.type === 'Identifier' &&
+            isCheck(expression.expression.right)
           ) {
-            expression.expression.arguments[0].elements.forEach((element) => {
-              if (element.type === 'Identifier')
-                checkedParams.push(element.name);
-            });
+            processCheckArgs(expression.expression.right.arguments);
           }
         });
       }

--- a/tests/lib/rules/audit-argument-checks.js
+++ b/tests/lib/rules/audit-argument-checks.js
@@ -42,6 +42,15 @@ ruleTester.run('audit-argument-checks', rule, {
       code: 'Meteor.publish("foo", function (bar) { checkId(bar); })',
       options: [{ checkEquivalents: ['checkId'] }],
     },
+    {
+      code:
+        'Meteor.publish("foo", function (bar) { var r; r = checkId(bar); })',
+      options: [{ checkEquivalents: ['checkId'] }],
+    },
+    {
+      code: 'Meteor.publish("foo", function () { checkId(); })',
+      options: [{ checkEquivalents: ['checkId'] }],
+    },
 
     'Meteor.methods()',
     'Meteor.methods({ x: function () {} })',


### PR DESCRIPTION
My custom `check` helpers return values.  This PR adds support for getting these return values while still considering the check function called.

It would be nice to be more general than just simple assignment statements (open to ideas!), but this is at least an improvement and suffices for my needs.